### PR TITLE
add glimpl_submit() before a stateful command glGetUniformSubroutineuiv

### DIFF
--- a/src/client/glimpl.c
+++ b/src/client/glimpl.c
@@ -8595,6 +8595,7 @@ void glGetUniformSubroutineuiv(GLenum shadertype, GLint location, GLuint* params
     pb_push(shadertype);
     pb_push(location);
 
+    glimpl_submit();
     *params = pb_read(SGL_OFFSET_REGISTER_RETVAL_V);
 }
 


### PR DESCRIPTION
Before the client fetches the return value by `*params = pb_read(SGL_OFFSET_REGISTER_RETVAL_V);`, it should always ensure proper synchronization by `glimpl_submit()`.